### PR TITLE
Removed preloading of miners

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,7 +1,6 @@
 package minercraft
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -126,9 +125,6 @@ func NewClient(clientOptions *ClientOptions, customHTTPClient *http.Client) (cli
 
 	// Create the new client
 	client = createClient(clientOptions, customHTTPClient)
-
-	// Load all known miners
-	err = json.Unmarshal([]byte(KnownMiners), &client.Miners)
 
 	return
 }

--- a/config.go
+++ b/config.go
@@ -33,29 +33,3 @@ const (
 	// MinerMatterpool is the name of the known miner for "Matterpool"
 	MinerMatterpool = "Matterpool"
 )
-
-// KnownMiners is a pre-filled list of known miners
-// Any pre-filled tokens are for free use only
-// update your custom token with client.MinerUpdateToken("name", "token")
-const KnownMiners = `
-[
-  {
-   "name": "Taal",
-   "miner_id": "03e92d3e5c3f7bd945dfbf48e7a99393b1bfb3f11f380ae30d286e7ff2aec5a270",
-   "token": "",
-   "url": "merchantapi.taal.com"
-  },
-  {
-   "name": "Mempool",
-   "miner_id": "03e92d3e5c3f7bd945dfbf48e7a99393b1bfb3f11f380ae30d286e7ff2aec5a270",
-   "token": "561b756d12572020ea9a104c3441b71790acbbce95a6ddbf7e0630971af9424b",
-   "url": "www.ddpurse.com/openapi"
-  },
-  {
-   "name": "Matterpool",
-   "miner_id": "0211ccfc29e3058b770f3cf3eb34b0b2fd2293057a994d4d275121be4151cdf087",
-   "token": "",
-   "url": "merchantapi.matterpool.io"
-  }
-]
-`


### PR DESCRIPTION
#6 I've removed the preloading of knownMiners as I think the library should provide complete flexibility over which miners we're connected to. We can do that by having no miners loaded initially and just adding the ones we need. Iif we do want to preload miners then we should perhaps use a library such as Viper that can potentially allow the user to override the default miners.