### PR TITLE
Fixed token not being identified by MAPI endpoint

### DIFF
--- a/request.go
+++ b/request.go
@@ -62,7 +62,7 @@ func httpRequest(ctx context.Context, client *Client, payload *httpPayload) (res
 
 	// Set a token if supplied
 	if len(payload.Token) > 0 {
-		request.Header.Set("token", payload.Token)
+		request.Header.Set("Authorization", payload.Token)
 	}
 
 	// Fire the http request


### PR DESCRIPTION
#10 token is identified through "Authorization" header and not "token"