### PR TITLE
Enhancement/mapi errors

### DIFF
--- a/request.go
+++ b/request.go
@@ -109,6 +109,7 @@ func httpRequest(ctx context.Context, client *Client,
 	}{}
 	if err := json.Unmarshal(response.BodyContents, &errBody); err != nil {
 		response.Error = fmt.Errorf("failed to unmarshal mapi error response: %w", err)
+		return
 	}
 	response.Error = fmt.Errorf(
 		"status code: %d does not match %d, error: %s",


### PR DESCRIPTION
If an error is received from an MAPI server the client currently just echos a 'status code x does not match status code y' message. This doesn't give us a lot of context to work with when debugging.

This PR resolves Issue https://github.com/tonicpow/go-minercraft/issues/21.

If status is OK then it just returns as before.

If there is a mismatch, we will check we have a body, if we do we attempt to map to an error type and then add the result to the error message. Otherwise we just echo the status code.

## Concerns

Do all errors / non 200 status codes have the same error format?