### PR TITLE
Merkle Proofs

### DIFF
--- a/submit_transaction.go
+++ b/submit_transaction.go
@@ -7,6 +7,10 @@ import (
 	"net/http"
 )
 
+const (
+	MerkleFormatTSC = "TSC"
+)
+
 /*
 Example Transaction Submission (submitted in the body of the request)
 {
@@ -24,8 +28,9 @@ type Transaction struct {
 	RawTx              string `json:"rawtx"`
 	CallBackURL        string `json:"callBackUrl,omitempty"`
 	CallBackToken      string `json:"callBackToken,omitempty"`
-	MerkleProof        string `json:"merkleProof,omitempty"`
-	DsCheck            string `json:"dsCheck,omitempty"`
+	MerkleProof        bool   `json:"merkleProof,omitempty"`
+	MerkleFormat       string `json:"merkleFormat,omitempty"`
+	DsCheck            bool   `json:"dsCheck,omitempty"`
 	CallBackEncryption string `json:"callBackEncryption,omitempty"`
 }
 

--- a/submit_transaction.go
+++ b/submit_transaction.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	// MerkleFormatTSC can be set when calling SubmitTransaction to request a MerkleProof in TSC format.
 	MerkleFormatTSC = "TSC"
 )
 
@@ -28,10 +29,10 @@ type Transaction struct {
 	RawTx              string `json:"rawtx"`
 	CallBackURL        string `json:"callBackUrl,omitempty"`
 	CallBackToken      string `json:"callBackToken,omitempty"`
-	MerkleProof        bool   `json:"merkleProof,omitempty"`
 	MerkleFormat       string `json:"merkleFormat,omitempty"`
-	DsCheck            bool   `json:"dsCheck,omitempty"`
 	CallBackEncryption string `json:"callBackEncryption,omitempty"`
+	MerkleProof        bool   `json:"merkleProof,omitempty"`
+	DsCheck            bool   `json:"dsCheck,omitempty"`
 }
 
 /*


### PR DESCRIPTION
Adding further support for the mAPI 1.3 data format, this is a small update though, it covers:

- Setting Proof and DsCheck as bools
- Adding MerkleFormat property to the Transaction submit request
